### PR TITLE
Fix 'tox -e generate_bundles' + rename it to update_bundle

### DIFF
--- a/.github/workflows/on_bundle_update_available.yaml
+++ b/.github/workflows/on_bundle_update_available.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Install tox
         run: python3 -m pip install tox
       - name: check for updates
-        run: tox -e generate_bundles
+        run: tox -e update_bundle
       - name: create pull request
         id: cpr
         uses: peter-evans/create-pull-request@v4

--- a/tox.ini
+++ b/tox.ini
@@ -56,7 +56,8 @@ commands =
     isort --check-only --diff {[vars]all_path}
     black --check --diff {[vars]all_path}
 
-[testenv:generate_bundles]
+[testenv:update_bundle]
+allowlist_externals = ./update_bundle.py
 description = Generate up-to-date bundles
 deps =
     requests


### PR DESCRIPTION
The tox.ini config line has been lost on rebases,
without allowlist_externals:

> tox -e generate_bundles
> generate_bundles: commands[0]> ./update_bundle.py releases/latest/machine/kafka/bundle.yaml
> generate_bundles: failed with ./update_bundle.py (resolves to ./update_bundle.py) is not allowed, use allowlist_externals to allow it
>   generate_bundles: FAIL code 1 (0.02 seconds)
>   evaluation failed :( (0.05 seconds)

Also while we are here, rename generate_bundles to update_bundle, as it is hard to recall tox name keeping in mind the script name. Let's sync them to follow K.I.S.S.