### PR TITLE
Move test app to jammy and update all (tls) libraries for test app

### DIFF
--- a/tests/integration/app-charm/charmcraft.yaml
+++ b/tests/integration/app-charm/charmcraft.yaml
@@ -14,7 +14,7 @@ parts:
 bases:
   - build-on:
       - name: "ubuntu"
-        channel: "20.04"
+        channel: "22.04"
     run-on:
       - name: "ubuntu"
-        channel: "20.04"
+        channel: "22.04"

--- a/tests/integration/app-charm/lib/charms/tls_certificates_interface/v1/tls_certificates.py
+++ b/tests/integration/app-charm/lib/charms/tls_certificates_interface/v1/tls_certificates.py
@@ -1,6 +1,7 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+
 """Library for the tls-certificates relation.
 
 This library contains the Requires and Provides classes for handling the tls-certificates
@@ -126,6 +127,7 @@ Example:
 from charms.tls_certificates_interface.v1.tls_certificates import (
     CertificateAvailableEvent,
     CertificateExpiringEvent,
+    CertificateRevokedEvent,
     TLSCertificatesRequiresV1,
     generate_csr,
     generate_private_key,
@@ -150,6 +152,9 @@ class ExampleRequirerCharm(CharmBase):
         )
         self.framework.observe(
             self.certificates.on.certificate_expiring, self._on_certificate_expiring
+        )
+        self.framework.observe(
+            self.certificates.on.certificate_revoked, self._on_certificate_revoked
         )
 
     def _on_install(self, event) -> None:
@@ -211,6 +216,30 @@ class ExampleRequirerCharm(CharmBase):
         )
         replicas_relation.data[self.app].update({"csr": new_csr.decode()})
 
+    def _on_certificate_revoked(self, event: CertificateRevokedEvent) -> None:
+        replicas_relation = self.model.get_relation("replicas")
+        if not replicas_relation:
+            self.unit.status = WaitingStatus("Waiting for peer relation to be created")
+            event.defer()
+            return
+        old_csr = replicas_relation.data[self.app].get("csr")
+        private_key_password = replicas_relation.data[self.app].get("private_key_password")
+        private_key = replicas_relation.data[self.app].get("private_key")
+        new_csr = generate_csr(
+            private_key=private_key.encode(),
+            private_key_password=private_key_password.encode(),
+            subject=self.cert_subject,
+        )
+        self.certificates.request_certificate_renewal(
+            old_certificate_signing_request=old_csr,
+            new_certificate_signing_request=new_csr,
+        )
+        replicas_relation.data[self.app].update({"csr": new_csr.decode()})
+        replicas_relation.data[self.app].pop("certificate")
+        replicas_relation.data[self.app].pop("ca")
+        replicas_relation.data[self.app].pop("chain")
+        self.unit.status = WaitingStatus("Waiting for new certificate")
+
 
 if __name__ == "__main__":
     main(ExampleRequirerCharm)
@@ -222,12 +251,15 @@ import json
 import logging
 import uuid
 from datetime import datetime, timedelta
+from ipaddress import IPv4Address
 from typing import Dict, List, Optional
 
 from cryptography import x509
+from cryptography.hazmat._oid import ExtensionOID
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.serialization import pkcs12
+from cryptography.x509.extensions import Extension, ExtensionNotFound
 from jsonschema import exceptions, validate  # type: ignore[import]
 from ops.charm import CharmBase, CharmEvents, RelationChangedEvent, UpdateStatusEvent
 from ops.framework import EventBase, EventSource, Handle, Object
@@ -240,7 +272,8 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 8
+LIBPATCH = 12
+
 
 REQUIRER_JSON_SCHEMA = {
     "$schema": "http://json-schema.org/draft-04/schema#",
@@ -280,7 +313,7 @@ PROVIDER_JSON_SCHEMA = {
     "type": "object",
     "title": "`tls_certificates` provider root schema",
     "description": "The `tls_certificates` root schema comprises the entire provider databag for this interface.",  # noqa: E501
-    "example": [
+    "examples": [
         {
             "certificates": [
                 {
@@ -292,7 +325,20 @@ PROVIDER_JSON_SCHEMA = {
                     "certificate": "-----BEGIN CERTIFICATE-----\nMIICvDCCAaQCFFPAOD7utDTsgFrm0vS4We18OcnKMA0GCSqGSIb3DQEBCwUAMCAx\nCzAJBgNVBAYTAlVTMREwDwYDVQQDDAh3aGF0ZXZlcjAeFw0yMjA3MjkyMTE5Mzha\nFw0yMzA3MjkyMTE5MzhaMBUxEzARBgNVBAMMCmJhbmFuYS5jb20wggEiMA0GCSqG\nSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDVpcfcBOnFuyZG+A2WQzmaBI5NXgwTCfvE\neKciqRQXhzJdUkEg7eqwFrK3y9yjhoiB6q0WNAeR+nOdS/Cw7layRtGz5skOq7Aa\nN4FZHg0or30i7Rrx7afJcGJyLpxfK/OfLmJm5QEdLXV0DZp0L5vuhhEb1EUOrMaY\nGe4iwqTyg6D7fuBili9dBVn9IvNhYMVgtiqkWVLTW4ChE0LgES4oO3rQZgp4dtM5\nsp6KwHGO766UzwGnkKRizaqmLylfVusllWNPFfp6gEaxa45N70oqGUrvGSVHWeHf\nfvkhpWx+wOnu+2A5F/Yv3UNz2v4g7Vjt7V0tjL4KMV9YklpRjTh3AgMBAAEwDQYJ\nKoZIhvcNAQELBQADggEBAChjRzuba8zjQ7NYBVas89Oy7u++MlS8xWxh++yiUsV6\nWMk3ZemsPtXc1YmXorIQohtxLxzUPm2JhyzFzU/sOLmJQ1E/l+gtZHyRCwsb20fX\nmphuJsMVd7qv/GwEk9PBsk2uDqg4/Wix0Rx5lf95juJP7CPXQJl5FQauf3+LSz0y\nwF/j+4GqvrwsWr9hKOLmPdkyKkR6bHKtzzsxL9PM8GnElk2OpaPMMnzbL/vt2IAt\nxK01ZzPxCQCzVwHo5IJO5NR/fIyFbEPhxzG17QsRDOBR9fl9cOIvDeSO04vyZ+nz\n+kA2c3fNrZFAtpIlOOmFh8Q12rVL4sAjI5mVWnNEgvI=\n-----END CERTIFICATE-----\n",  # noqa: E501
                 }
             ]
-        }
+        },
+        {
+            "certificates": [
+                {
+                    "ca": "-----BEGIN CERTIFICATE-----\\nMIIDJTCCAg2gAwIBAgIUMsSK+4FGCjW6sL/EXMSxColmKw8wDQYJKoZIhvcNAQEL\\nBQAwIDELMAkGA1UEBhMCVVMxETAPBgNVBAMMCHdoYXRldmVyMB4XDTIyMDcyOTIx\\nMTgyN1oXDTIzMDcyOTIxMTgyN1owIDELMAkGA1UEBhMCVVMxETAPBgNVBAMMCHdo\\nYXRldmVyMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA55N9DkgFWbJ/\\naqcdQhso7n1kFvt6j/fL1tJBvRubkiFMQJnZFtekfalN6FfRtA3jq+nx8o49e+7t\\nLCKT0xQ+wufXfOnxv6/if6HMhHTiCNPOCeztUgQ2+dfNwRhYYgB1P93wkUVjwudK\\n13qHTTZ6NtEF6EzOqhOCe6zxq6wrr422+ZqCvcggeQ5tW9xSd/8O1vNID/0MTKpy\\nET3drDtBfHmiUEIBR3T3tcy6QsIe4Rz/2sDinAcM3j7sG8uY6drh8jY3PWar9til\\nv2l4qDYSU8Qm5856AB1FVZRLRJkLxZYZNgreShAIYgEd0mcyI2EO/UvKxsIcxsXc\\nd45GhGpKkwIDAQABo1cwVTAfBgNVHQ4EGAQWBBRXBrXKh3p/aFdQjUcT/UcvICBL\\nODAhBgNVHSMEGjAYgBYEFFcGtcqHen9oV1CNRxP9Ry8gIEs4MA8GA1UdEwEB/wQF\\nMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAGmCEvcoFUrT9e133SHkgF/ZAgzeIziO\\nBjfAdU4fvAVTVfzaPm0yBnGqzcHyacCzbZjKQpaKVgc5e6IaqAQtf6cZJSCiJGhS\\nJYeosWrj3dahLOUAMrXRr8G/Ybcacoqc+osKaRa2p71cC3V6u2VvcHRV7HDFGJU7\\noijbdB+WhqET6Txe67rxZCJG9Ez3EOejBJBl2PJPpy7m1Ml4RR+E8YHNzB0lcBzc\\nEoiJKlDfKSO14E2CPDonnUoWBJWjEvJys3tbvKzsRj2fnLilytPFU0gH3cEjCopi\\nzFoWRdaRuNHYCqlBmso1JFDl8h4fMmglxGNKnKRar0WeGyxb4xXBGpI=\\n-----END CERTIFICATE-----\\n",  # noqa: E501
+                    "chain": [
+                        "-----BEGIN CERTIFICATE-----\\nMIIDJTCCAg2gAwIBAgIUMsSK+4FGCjW6sL/EXMSxColmKw8wDQYJKoZIhvcNAQEL\\nBQAwIDELMAkGA1UEBhMCVVMxETAPBgNVBAMMCHdoYXRldmVyMB4XDTIyMDcyOTIx\\nMTgyN1oXDTIzMDcyOTIxMTgyN1owIDELMAkGA1UEBhMCVVMxETAPBgNVBAMMCHdo\\nYXRldmVyMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA55N9DkgFWbJ/\\naqcdQhso7n1kFvt6j/fL1tJBvRubkiFMQJnZFtekfalN6FfRtA3jq+nx8o49e+7t\\nLCKT0xQ+wufXfOnxv6/if6HMhHTiCNPOCeztUgQ2+dfNwRhYYgB1P93wkUVjwudK\\n13qHTTZ6NtEF6EzOqhOCe6zxq6wrr422+ZqCvcggeQ5tW9xSd/8O1vNID/0MTKpy\\nET3drDtBfHmiUEIBR3T3tcy6QsIe4Rz/2sDinAcM3j7sG8uY6drh8jY3PWar9til\\nv2l4qDYSU8Qm5856AB1FVZRLRJkLxZYZNgreShAIYgEd0mcyI2EO/UvKxsIcxsXc\\nd45GhGpKkwIDAQABo1cwVTAfBgNVHQ4EGAQWBBRXBrXKh3p/aFdQjUcT/UcvICBL\\nODAhBgNVHSMEGjAYgBYEFFcGtcqHen9oV1CNRxP9Ry8gIEs4MA8GA1UdEwEB/wQF\\nMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAGmCEvcoFUrT9e133SHkgF/ZAgzeIziO\\nBjfAdU4fvAVTVfzaPm0yBnGqzcHyacCzbZjKQpaKVgc5e6IaqAQtf6cZJSCiJGhS\\nJYeosWrj3dahLOUAMrXRr8G/Ybcacoqc+osKaRa2p71cC3V6u2VvcHRV7HDFGJU7\\noijbdB+WhqET6Txe67rxZCJG9Ez3EOejBJBl2PJPpy7m1Ml4RR+E8YHNzB0lcBzc\\nEoiJKlDfKSO14E2CPDonnUoWBJWjEvJys3tbvKzsRj2fnLilytPFU0gH3cEjCopi\\nzFoWRdaRuNHYCqlBmso1JFDl8h4fMmglxGNKnKRar0WeGyxb4xXBGpI=\\n-----END CERTIFICATE-----\\n"  # noqa: E501, W505
+                    ],
+                    "certificate_signing_request": "-----BEGIN CERTIFICATE REQUEST-----\nMIICWjCCAUICAQAwFTETMBEGA1UEAwwKYmFuYW5hLmNvbTCCASIwDQYJKoZIhvcN\nAQEBBQADggEPADCCAQoCggEBANWlx9wE6cW7Jkb4DZZDOZoEjk1eDBMJ+8R4pyKp\nFBeHMl1SQSDt6rAWsrfL3KOGiIHqrRY0B5H6c51L8LDuVrJG0bPmyQ6rsBo3gVke\nDSivfSLtGvHtp8lwYnIunF8r858uYmblAR0tdXQNmnQvm+6GERvURQ6sxpgZ7iLC\npPKDoPt+4GKWL10FWf0i82FgxWC2KqRZUtNbgKETQuARLig7etBmCnh20zmynorA\ncY7vrpTPAaeQpGLNqqYvKV9W6yWVY08V+nqARrFrjk3vSioZSu8ZJUdZ4d9++SGl\nbH7A6e77YDkX9i/dQ3Pa/iDtWO3tXS2MvgoxX1iSWlGNOHcCAwEAAaAAMA0GCSqG\nSIb3DQEBCwUAA4IBAQCW1fKcHessy/ZhnIwAtSLznZeZNH8LTVOzkhVd4HA7EJW+\nKVLBx8DnN7L3V2/uPJfHiOg4Rx7fi7LkJPegl3SCqJZ0N5bQS/KvDTCyLG+9E8Y+\n7wqCmWiXaH1devimXZvazilu4IC2dSks2D8DPWHgsOdVks9bme8J3KjdNMQudegc\newWZZ1Dtbd+Rn7cpKU3jURMwm4fRwGxbJ7iT5fkLlPBlyM/yFEik4SmQxFYrZCQg\n0f3v4kBefTh5yclPy5tEH+8G0LMsbbo3dJ5mPKpAShi0QEKDLd7eR1R/712lYTK4\ndi4XaEfqERgy68O4rvb4PGlJeRGS7AmL7Ss8wfAq\n-----END CERTIFICATE REQUEST-----\n",  # noqa: E501
+                    "certificate": "-----BEGIN CERTIFICATE-----\nMIICvDCCAaQCFFPAOD7utDTsgFrm0vS4We18OcnKMA0GCSqGSIb3DQEBCwUAMCAx\nCzAJBgNVBAYTAlVTMREwDwYDVQQDDAh3aGF0ZXZlcjAeFw0yMjA3MjkyMTE5Mzha\nFw0yMzA3MjkyMTE5MzhaMBUxEzARBgNVBAMMCmJhbmFuYS5jb20wggEiMA0GCSqG\nSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDVpcfcBOnFuyZG+A2WQzmaBI5NXgwTCfvE\neKciqRQXhzJdUkEg7eqwFrK3y9yjhoiB6q0WNAeR+nOdS/Cw7layRtGz5skOq7Aa\nN4FZHg0or30i7Rrx7afJcGJyLpxfK/OfLmJm5QEdLXV0DZp0L5vuhhEb1EUOrMaY\nGe4iwqTyg6D7fuBili9dBVn9IvNhYMVgtiqkWVLTW4ChE0LgES4oO3rQZgp4dtM5\nsp6KwHGO766UzwGnkKRizaqmLylfVusllWNPFfp6gEaxa45N70oqGUrvGSVHWeHf\nfvkhpWx+wOnu+2A5F/Yv3UNz2v4g7Vjt7V0tjL4KMV9YklpRjTh3AgMBAAEwDQYJ\nKoZIhvcNAQELBQADggEBAChjRzuba8zjQ7NYBVas89Oy7u++MlS8xWxh++yiUsV6\nWMk3ZemsPtXc1YmXorIQohtxLxzUPm2JhyzFzU/sOLmJQ1E/l+gtZHyRCwsb20fX\nmphuJsMVd7qv/GwEk9PBsk2uDqg4/Wix0Rx5lf95juJP7CPXQJl5FQauf3+LSz0y\nwF/j+4GqvrwsWr9hKOLmPdkyKkR6bHKtzzsxL9PM8GnElk2OpaPMMnzbL/vt2IAt\nxK01ZzPxCQCzVwHo5IJO5NR/fIyFbEPhxzG17QsRDOBR9fl9cOIvDeSO04vyZ+nz\n+kA2c3fNrZFAtpIlOOmFh8Q12rVL4sAjI5mVWnNEgvI=\n-----END CERTIFICATE-----\n",  # noqa: E501
+                    "revoked": True,
+                }
+            ]
+        },
     ],
     "properties": {
         "certificates": {
@@ -319,6 +365,10 @@ PROVIDER_JSON_SCHEMA = {
                             "type": "string",
                             "$id": "#/properties/certificates/items/chain/items",
                         },
+                    },
+                    "revoked": {
+                        "$id": "#/properties/certificates/items/revoked",
+                        "type": "boolean",
                     },
                 },
                 "additionalProperties": True,
@@ -407,6 +457,44 @@ class CertificateExpiredEvent(EventBase):
     def restore(self, snapshot: dict):
         """Restores snapshot."""
         self.certificate = snapshot["certificate"]
+
+
+class CertificateRevokedEvent(EventBase):
+    """Charm Event triggered when a TLS certificate is revoked."""
+
+    def __init__(
+        self,
+        handle: Handle,
+        certificate: str,
+        certificate_signing_request: str,
+        ca: str,
+        chain: List[str],
+        revoked: bool,
+    ):
+        super().__init__(handle)
+        self.certificate = certificate
+        self.certificate_signing_request = certificate_signing_request
+        self.ca = ca
+        self.chain = chain
+        self.revoked = revoked
+
+    def snapshot(self) -> dict:
+        """Returns snapshot."""
+        return {
+            "certificate": self.certificate,
+            "certificate_signing_request": self.certificate_signing_request,
+            "ca": self.ca,
+            "chain": self.chain,
+            "revoked": self.revoked,
+        }
+
+    def restore(self, snapshot: dict):
+        """Restores snapshot."""
+        self.certificate = snapshot["certificate"]
+        self.certificate_signing_request = snapshot["certificate_signing_request"]
+        self.ca = snapshot["ca"]
+        self.chain = snapshot["chain"]
+        self.revoked = snapshot["revoked"]
 
 
 class CertificateCreationRequestEvent(EventBase):
@@ -548,7 +636,7 @@ def generate_certificate(
     ca_key: bytes,
     ca_key_password: Optional[bytes] = None,
     validity: int = 365,
-    alt_names: list = None,
+    alt_names: Optional[List[str]] = None,
 ) -> bytes:
     """Generates a TLS certificate based on a CSR.
 
@@ -558,7 +646,7 @@ def generate_certificate(
         ca_key (bytes): CA private key
         ca_key_password: CA private key password
         validity (int): Certificate validity (in days)
-        alt_names: Certificate Subject alternative names
+        alt_names (list): List of alt names to put on cert - prefer putting SANs in CSR
 
     Returns:
         bytes: Certificate
@@ -577,13 +665,36 @@ def generate_certificate(
         .not_valid_before(datetime.utcnow())
         .not_valid_after(datetime.utcnow() + timedelta(days=validity))
     )
+
+    extensions_list = csr_object.extensions
+    san_ext: Optional[x509.Extension] = None
     if alt_names:
-        names = [x509.DNSName(n) for n in alt_names]
+        full_sans_dns = alt_names.copy()
+        try:
+            loaded_san_ext = csr_object.extensions.get_extension_for_class(
+                x509.SubjectAlternativeName
+            )
+            full_sans_dns.extend(loaded_san_ext.value.get_values_for_type(x509.DNSName))
+        except ExtensionNotFound:
+            pass
+        finally:
+            san_ext = Extension(
+                ExtensionOID.SUBJECT_ALTERNATIVE_NAME,
+                False,
+                x509.SubjectAlternativeName([x509.DNSName(name) for name in full_sans_dns]),
+            )
+            if not extensions_list:
+                extensions_list = x509.Extensions([san_ext])
+
+    for extension in extensions_list:
+        if extension.value.oid == ExtensionOID.SUBJECT_ALTERNATIVE_NAME and san_ext:
+            extension = san_ext
+
         certificate_builder = certificate_builder.add_extension(
-            x509.SubjectAlternativeName(names),
-            critical=False,
+            extension.value,
+            critical=extension.critical,
         )
-    certificate_builder._version = x509.Version.v1
+    certificate_builder._version = x509.Version.v3
     cert = certificate_builder.sign(private_key, hashes.SHA256())  # type: ignore[arg-type]
     return cert.public_bytes(serialization.Encoding.PEM)
 
@@ -653,11 +764,14 @@ def generate_csr(
     private_key: bytes,
     subject: str,
     add_unique_id_to_subject_name: bool = True,
-    organization: str = None,
-    email_address: str = None,
-    country_name: str = None,
+    organization: Optional[str] = None,
+    email_address: Optional[str] = None,
+    country_name: Optional[str] = None,
     private_key_password: Optional[bytes] = None,
     sans: Optional[List[str]] = None,
+    sans_oid: Optional[List[str]] = None,
+    sans_ip: Optional[List[str]] = None,
+    sans_dns: Optional[List[str]] = None,
     additional_critical_extensions: Optional[List] = None,
 ) -> bytes:
     """Generates a CSR using private key and subject.
@@ -672,7 +786,11 @@ def generate_csr(
         email_address (str): Email address.
         country_name (str): Country Name.
         private_key_password (bytes): Private key password
-        sans (list): List of subject alternative names
+        sans (list): Use sans_dns - this will be deprecated in a future release
+            List of DNS subject alternative names (keeping it for now for backward compatibility)
+        sans_oid (list): List of registered ID SANs
+        sans_dns (list): List of DNS subject alternative names (similar to the arg: sans)
+        sans_ip (list): List of IP subject alternative names
         additional_critical_extensions (list): List if critical additional extension objects.
             Object must be a x509 ExtensionType.
 
@@ -693,13 +811,23 @@ def generate_csr(
     if country_name:
         subject_name.append(x509.NameAttribute(x509.NameOID.COUNTRY_NAME, country_name))
     csr = x509.CertificateSigningRequestBuilder(subject_name=x509.Name(subject_name))
+
+    _sans: List[x509.GeneralName] = []
+    if sans_oid:
+        _sans.extend([x509.RegisteredID(x509.ObjectIdentifier(san)) for san in sans_oid])
+    if sans_ip:
+        _sans.extend([x509.IPAddress(IPv4Address(san)) for san in sans_ip])
     if sans:
-        csr = csr.add_extension(
-            x509.SubjectAlternativeName([x509.DNSName(san) for san in sans]), critical=False
-        )
+        _sans.extend([x509.DNSName(san) for san in sans])
+    if sans_dns:
+        _sans.extend([x509.DNSName(san) for san in sans_dns])
+    if _sans:
+        csr = csr.add_extension(x509.SubjectAlternativeName(set(_sans)), critical=False)
+
     if additional_critical_extensions:
         for extension in additional_critical_extensions:
             csr = csr.add_extension(extension, critical=True)
+
     signed_certificate = csr.sign(signing_key, hashes.SHA256())  # type: ignore[arg-type]
     return signed_certificate.public_bytes(serialization.Encoding.PEM)
 
@@ -717,6 +845,7 @@ class CertificatesRequirerCharmEvents(CharmEvents):
     certificate_available = EventSource(CertificateAvailableEvent)
     certificate_expiring = EventSource(CertificateExpiringEvent)
     certificate_expired = EventSource(CertificateExpiredEvent)
+    certificate_revoked = EventSource(CertificateRevokedEvent)
 
 
 class TLSCertificatesProvidesV1(Object):
@@ -778,8 +907,8 @@ class TLSCertificatesProvidesV1(Object):
     def _remove_certificate(
         self,
         relation_id: int,
-        certificate: str = None,
-        certificate_signing_request: str = None,
+        certificate: Optional[str] = None,
+        certificate_signing_request: Optional[str] = None,
     ) -> None:
         """Removes certificate from a given relation based on user provided certificate or csr.
 
@@ -827,6 +956,18 @@ class TLSCertificatesProvidesV1(Object):
             return True
         except exceptions.ValidationError:
             return False
+
+    def revoke_all_certificates(self) -> None:
+        """Revokes all certificates of this provider.
+
+        This method is meant to be used when the Root CA has changed.
+        """
+        for relation in self.model.relations[self.relationship_name]:
+            provider_relation_data = _load_relation_data(relation.data[self.charm.app])
+            provider_certificates = copy.deepcopy(provider_relation_data.get("certificates", []))
+            for certificate in provider_certificates:
+                certificate["revoked"] = True
+            relation.data[self.model.app]["certificates"] = json.dumps(provider_certificates)
 
     def set_relation_certificate(
         self,
@@ -881,7 +1022,7 @@ class TLSCertificatesProvidesV1(Object):
             self._remove_certificate(certificate=certificate, relation_id=certificate_relation.id)
 
     def _on_relation_changed(self, event: RelationChangedEvent) -> None:
-        """Handler triggered on relation changed event.
+        """Handler triggerred on relation changed event.
 
         Looks at the relation data and either emits:
         - certificate request event: If the unit relation data contains a CSR for which
@@ -895,6 +1036,7 @@ class TLSCertificatesProvidesV1(Object):
         Returns:
             None
         """
+        assert event.unit is not None
         requirer_relation_data = _load_relation_data(event.relation.data[event.unit])
         provider_relation_data = _load_relation_data(event.relation.data[self.charm.app])
         if not self._relation_data_is_valid(requirer_relation_data):
@@ -923,8 +1065,8 @@ class TLSCertificatesProvidesV1(Object):
     def _revoke_certificates_for_which_no_csr_exists(self, relation_id: int) -> None:
         """Revokes certificates for which no unit has a CSR.
 
-        Goes through all generated certificates and compare against the list of CSRS for all
-        units of a given relationship.
+        Goes through all generated certificates and compare agains the list of CSRS for all units
+        of a given relationship.
 
         Args:
             relation_id (int): Relation id
@@ -1146,7 +1288,7 @@ class TLSCertificatesRequiresV1(Object):
         if not self._relation_data_is_valid(provider_relation_data):
             logger.warning(
                 f"Provider relation data did not pass JSON Schema validation: "
-                f"{event.relation.data[event.app]}"
+                f"{event.relation.data[relation.app]}"
             )
             return
         requirer_csrs = [
@@ -1155,12 +1297,21 @@ class TLSCertificatesRequiresV1(Object):
         ]
         for certificate in self._provider_certificates:
             if certificate["certificate_signing_request"] in requirer_csrs:
-                self.on.certificate_available.emit(
-                    certificate_signing_request=certificate["certificate_signing_request"],
-                    certificate=certificate["certificate"],
-                    ca=certificate["ca"],
-                    chain=certificate["chain"],
-                )
+                if certificate.get("revoked", False):
+                    self.on.certificate_revoked.emit(
+                        certificate_signing_request=certificate["certificate_signing_request"],
+                        certificate=certificate["certificate"],
+                        ca=certificate["ca"],
+                        chain=certificate["chain"],
+                        revoked=True,
+                    )
+                else:
+                    self.on.certificate_available.emit(
+                        certificate_signing_request=certificate["certificate_signing_request"],
+                        certificate=certificate["certificate"],
+                        ca=certificate["ca"],
+                        chain=certificate["chain"],
+                    )
 
     def _on_update_status(self, event: UpdateStatusEvent) -> None:
         """Triggered on update status event.

--- a/tox.ini
+++ b/tox.ini
@@ -51,6 +51,7 @@ commands =
     codespell {tox_root} --skip {tox_root}/.git --skip {tox_root}/.tox \
       --skip {tox_root}/build --skip {tox_root}/lib --skip {tox_root}/venv \
       --skip {tox_root}/.mypy_cache --skip {tox_root}/icon.svg
+      --skip {tox_root}/tests/integration/app-charm/lib
     # pflake8 wrapper supports config from pyproject.toml
     pflake8 {[vars]all_path}
     isort --check-only --diff {[vars]all_path}

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,7 @@ commands =
     ; codespell {[vars]lib_path}
     codespell {tox_root} --skip {tox_root}/.git --skip {tox_root}/.tox \
       --skip {tox_root}/build --skip {tox_root}/lib --skip {tox_root}/venv \
-      --skip {tox_root}/.mypy_cache --skip {tox_root}/icon.svg
+      --skip {tox_root}/.mypy_cache --skip {tox_root}/icon.svg \
       --skip {tox_root}/tests/integration/app-charm/lib
     # pflake8 wrapper supports config from pyproject.toml
     pflake8 {[vars]all_path}


### PR DESCRIPTION
Otherwise test app charm is not buildable which locks PR. Somohow the previous commit of migcation bundle to jammy affect test app now.

Example of the error: https://github.com/canonical/kafka-bundle/pull/43
> INFO     pytest_operator.plugin:plugin.py:942 Charm build for application completed with errors (return code=1) in 386.09s
> FAILED

The local build:
> Parts processing error: Failed to run the build script for part 'charm'.
> Failed to build charm for bases index '0'.

Debug log:
> 2023-03-09 10:42:58.868 Packing the charm
> 2023-03-09 10:42:58.869 Running ['charmcraft', 'pack', '--bases-index', '0', '--verbosity=brief']
> 2023-03-09 10:42:58.869 Emitter: Pausing control of the terminal
> 2023-03-09 10:43:28.763 Emitter: Resuming control of the terminal
> 2023-03-09 10:43:28.955 Interrupted.
> 2023-03-09 10:43:28.960 Traceback (most recent call last):
> 2023-03-09 10:43:28.960   File "/snap/charmcraft/1171/lib/charmcraft/commands/build.py", line 376, in pack_charm_in_instance
> 2023-03-09 10:43:28.960     instance.execute_run(cmd, check=True, cwd=instance_output_dir)
> 2023-03-09 10:43:28.960   File "/snap/charmcraft/1171/lib/craft_providers/lxd/lxd_instance.py", line 289, in execute_run
> 2023-03-09 10:43:28.960     return self.lxc.exec(
> 2023-03-09 10:43:28.960   File "/snap/charmcraft/1171/lib/craft_providers/lxd/lxc.py", line 329, in exec
> 2023-03-09 10:43:28.960     return runner(final_cmd, **kwargs)  # pylint: disable=subprocess-run-check
> 2023-03-09 10:43:28.960   File "/snap/charmcraft/1171/usr/lib/python3.8/subprocess.py", line 516, in run
> 2023-03-09 10:43:28.960     raise CalledProcessError(retcode, process.args,
> 2023-03-09 10:43:28.960 subprocess.CalledProcessError: Command '['lxc', '--project', 'charmcraft', 'exec', 'local:charmcraft-application-96474887-0-0-amd64', '--cwd', '/root/project', '--', 'env', 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin', 'CHARMCRAFT_MANAGED_MODE=1', 'charmcraft', 'pack', '--bases-index', '0', '--verbosity=brief']' returned non-zero exit status 1.
> 2023-03-09 10:43:28.960
> 2023-03-09 10:43:28.960 The above exception was the direct cause of the following exception:
> 2023-03-09 10:43:28.960 Traceback (most recent call last):
> 2023-03-09 10:43:28.960   File "/snap/charmcraft/1171/lib/charmcraft/commands/build.py", line 381, in pack_charm_in_instance
> 2023-03-09 10:43:28.960     raise CraftError(
> 2023-03-09 10:43:28.960 craft_cli.errors.CraftError: Failed to build charm for bases index '0'.
> 2023-03-09 10:43:28.960
> 2023-03-09 10:43:28.960 During handling of the above exception, another exception occurred:
> 2023-03-09 10:43:28.960 Traceback (most recent call last):
> 2023-03-09 10:43:28.960   File "/snap/charmcraft/1171/lib/craft_providers/lxd/lxd_provider.py", line 143, in launched_environment
> 2023-03-09 10:43:28.960     yield instance
> 2023-03-09 10:43:28.960   File "/snap/charmcraft/1171/lib/charmcraft/commands/build.py", line 385, in pack_charm_in_instance
> 2023-03-09 10:43:28.960     providers.capture_logs_from_instance(instance)
> 2023-03-09 10:43:28.960   File "/snap/charmcraft/1171/lib/charmcraft/providers.py", line 202, in capture_logs_from_instance
> 2023-03-09 10:43:28.960     with instance.temporarily_pull_file(source=source_log_path, missing_ok=True) as local_log_path:
> 2023-03-09 10:43:28.960   File "/snap/charmcraft/1171/usr/lib/python3.8/contextlib.py", line 113, in __enter__
> 2023-03-09 10:43:28.960     return next(self.gen)
> 2023-03-09 10:43:28.960   File "/snap/charmcraft/1171/lib/craft_providers/executor.py", line 119, in temporarily_pull_file
> 2023-03-09 10:43:28.960     self.pull_file(source=source, destination=tmp_file)
> 2023-03-09 10:43:28.960   File "/snap/charmcraft/1171/lib/craft_providers/lxd/lxd_instance.py", line 467, in pull_file
> 2023-03-09 10:43:28.960     proc = self.execute_run(["test", "-f", source.as_posix()], check=False)
> 2023-03-09 10:43:28.960   File "/snap/charmcraft/1171/lib/craft_providers/lxd/lxd_instance.py", line 289, in execute_run
> 2023-03-09 10:43:28.960     return self.lxc.exec(
> 2023-03-09 10:43:28.960   File "/snap/charmcraft/1171/lib/craft_providers/lxd/lxc.py", line 329, in exec
> 2023-03-09 10:43:28.960     return runner(final_cmd, **kwargs)  # pylint: disable=subprocess-run-check
> 2023-03-09 10:43:28.960   File "/snap/charmcraft/1171/usr/lib/python3.8/subprocess.py", line 495, in run
> 2023-03-09 10:43:28.960     stdout, stderr = process.communicate(input, timeout=timeout)
> 2023-03-09 10:43:28.960   File "/snap/charmcraft/1171/usr/lib/python3.8/subprocess.py", line 1020, in communicate
> 2023-03-09 10:43:28.960     self.wait()
> 2023-03-09 10:43:28.960   File "/snap/charmcraft/1171/usr/lib/python3.8/subprocess.py", line 1083, in wait
> 2023-03-09 10:43:28.960     return self._wait(timeout=timeout)
> 2023-03-09 10:43:28.960   File "/snap/charmcraft/1171/usr/lib/python3.8/subprocess.py", line 1806, in _wait
> 2023-03-09 10:43:28.960     (pid, sts) = self._try_wait(0)
> 2023-03-09 10:43:28.960   File "/snap/charmcraft/1171/usr/lib/python3.8/subprocess.py", line 1764, in _try_wait
> 2023-03-09 10:43:28.960     (pid, sts) = os.waitpid(self.pid, wait_flags)
> 2023-03-09 10:43:28.960 KeyboardInterrupt
> 2023-03-09 10:43:28.960
> 2023-03-09 10:43:28.960 During handling of the above exception, another exception occurred:
> 2023-03-09 10:43:28.960 Traceback (most recent call last):
> 2023-03-09 10:43:28.960   File "/snap/charmcraft/1171/lib/charmcraft/main.py", line 184, in main
> 2023-03-09 10:43:28.960     retcode = dispatcher.run()
> 2023-03-09 10:43:28.960   File "/snap/charmcraft/1171/lib/craft_cli/dispatcher.py", line 448, in run
> 2023-03-09 10:43:28.960     return self._loaded_command.run(self._parsed_command_args)
> 2023-03-09 10:43:28.960   File "/snap/charmcraft/1171/lib/charmcraft/commands/pack.py", line 133, in run
> 2023-03-09 10:43:28.960     pack_method(parsed_args)
> 2023-03-09 10:43:28.960   File "/snap/charmcraft/1171/lib/charmcraft/commands/pack.py", line 165, in _pack_charm
> 2023-03-09 10:43:28.960     charms = builder.run(
> 2023-03-09 10:43:28.960   File "/snap/charmcraft/1171/lib/charmcraft/instrum.py", line 152, in _f
> 2023-03-09 10:43:28.960     return func(*args, **kwargs)
> 2023-03-09 10:43:28.960   File "/snap/charmcraft/1171/lib/charmcraft/commands/build.py", line 292, in run
> 2023-03-09 10:43:28.960     charm_name = self.pack_charm_in_instance(
> 2023-03-09 10:43:28.960   File "/snap/charmcraft/1171/lib/charmcraft/commands/build.py", line 394, in pack_charm_in_instance
> 2023-03-09 10:43:28.960     raise CraftError("Unexpected error retrieving charm from instance.") from error
> 2023-03-09 10:43:28.960   File "/snap/charmcraft/1171/usr/lib/python3.8/contextlib.py", line 131, in __exit__
> 2023-03-09 10:43:28.960     self.gen.throw(type, value, traceback)
> 2023-03-09 10:43:28.960   File "/snap/charmcraft/1171/lib/craft_providers/lxd/lxd_provider.py", line 146, in launched_environment
> 2023-03-09 10:43:28.960     instance.unmount_all()
> 2023-03-09 10:43:28.960   File "/snap/charmcraft/1171/lib/craft_providers/lxd/lxd_instance.py", line 580, in unmount_all
> 2023-03-09 10:43:28.960     self.lxc.config_device_remove(
> 2023-03-09 10:43:28.960   File "/snap/charmcraft/1171/lib/craft_providers/lxd/lxc.py", line 171, in config_device_remove
> 2023-03-09 10:43:28.960     self._run_lxc(
> 2023-03-09 10:43:28.960   File "/snap/charmcraft/1171/lib/craft_providers/lxd/lxc.py", line 98, in _run_lxc
> 2023-03-09 10:43:28.960     return subprocess.run(lxc_cmd, check=check, stdin=stdin.value, **kwargs)
> 2023-03-09 10:43:28.960   File "/snap/charmcraft/1171/usr/lib/python3.8/subprocess.py", line 495, in run
> 2023-03-09 10:43:28.960     stdout, stderr = process.communicate(input, timeout=timeout)
> 2023-03-09 10:43:28.960   File "/snap/charmcraft/1171/usr/lib/python3.8/subprocess.py", line 1028, in communicate
> 2023-03-09 10:43:28.960     stdout, stderr = self._communicate(input, endtime, timeout)
> 2023-03-09 10:43:28.960   File "/snap/charmcraft/1171/usr/lib/python3.8/subprocess.py", line 1868, in _communicate
> 2023-03-09 10:43:28.960     ready = selector.select(timeout)
> 2023-03-09 10:43:28.960   File "/snap/charmcraft/1171/usr/lib/python3.8/selectors.py", line 415, in select
> 2023-03-09 10:43:28.960     fd_event_list = self._selector.poll(timeout)
> 2023-03-09 10:43:28.960 KeyboardInterrupt
> 2023-03-09 10:43:28.960 Full execution log: '/home/taurus/.local/state/charmcraft/log/charmcraft-20230309-104240.697710.log'