### PR TITLE
Add database parameter in e2e tests

### DIFF
--- a/tests/integration/e2e/conftest.py
+++ b/tests/integration/e2e/conftest.py
@@ -50,6 +50,13 @@ def pytest_addoption(parser):
         help="set usage of credentials provided by the data-integrator.",
     )
 
+    parser.addoption(
+        "--database",
+        action="store",
+        help="name of pre-deployed mongoDB instance.",
+        default=DATABASE_CHARM_NAME,
+    )
+
 
 def pytest_generate_tests(metafunc):
     """Processes pytest parsers."""
@@ -72,6 +79,10 @@ def pytest_generate_tests(metafunc):
     integrator = metafunc.config.option.integrator
     if "integrator" in metafunc.fixturenames:
         metafunc.parametrize("integrator", [bool(integrator)], scope="module")
+
+    database = metafunc.config.option.database
+    if "database" in metafunc.fixturenames:
+        metafunc.parametrize("database", [database], scope="module")
 
 
 ### - FIXTURES - ###
@@ -191,7 +202,7 @@ async def deploy_data_integrator(ops_test: OpsTest, kafka):
 
 
 @pytest.fixture(scope="function")
-async def deploy_test_app(ops_test: OpsTest, kafka, certificates, tls):
+async def deploy_test_app(ops_test: OpsTest, kafka, certificates, database, tls):
     """Factory fixture for deploying + tearing down client applications."""
     # tracks deployed app names for teardown later
     apps = []
@@ -242,9 +253,9 @@ async def deploy_test_app(ops_test: OpsTest, kafka, certificates, tls):
             )
 
         # Relate with MongoDB
-        await ops_test.model.add_relation(generated_app_name, DATABASE_CHARM_NAME)
+        await ops_test.model.add_relation(generated_app_name, database)
         await ops_test.model.wait_for_idle(
-            apps=[generated_app_name, DATABASE_CHARM_NAME],
+            apps=[generated_app_name, database],
             idle_period=30,
             status="active",
             timeout=1800,

--- a/tests/integration/e2e/conftest.py
+++ b/tests/integration/e2e/conftest.py
@@ -122,7 +122,7 @@ async def deploy_cluster(ops_test: OpsTest, tls):
                 apps=[KAFKA_CHARM_NAME, ZOOKEEPER_CHARM_NAME],
                 idle_period=10,
                 status="active",
-                timeout=600,
+                timeout=1200,
             )
 
     async def _deploy_tls_cluster():
@@ -281,3 +281,8 @@ async def deploy_test_app(ops_test: OpsTest, kafka, certificates, database, tls)
             logger.info(f"App: {app} already removed!")
 
     await ops_test.model.wait_for_idle(apps=[kafka], idle_period=30, status="active", timeout=1800)
+
+
+def pytest_configure():
+    """Pytest configuration parameters."""
+    pytest.remove_database = False

--- a/tests/integration/e2e/test_basic_flow.py
+++ b/tests/integration/e2e/test_basic_flow.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 
 import pytest
-from literals import DATABASE_CHARM_NAME, KAFKA_CHARM_NAME, ZOOKEEPER_CHARM_NAME
+from literals import DATABASE_CHARM_NAME
 from pytest_operator.plugin import OpsTest
 from tests.integration.e2e.helpers import (
     check_produced_and_consumed_messages,
@@ -30,7 +30,7 @@ async def test_deploy(ops_test: OpsTest, deploy_cluster):
 
 @pytest.mark.abort_on_fail
 async def test_cluster_is_deployed_successfully(
-    ops_test: OpsTest, kafka, zookeeper, tls, certificates
+    ops_test: OpsTest, kafka, zookeeper, tls, certificates, database
 ):
     assert ops_test.model.applications[kafka].status == "active"
     assert ops_test.model.applications[zookeeper].status == "active"
@@ -38,23 +38,23 @@ async def test_cluster_is_deployed_successfully(
     if tls:
         assert ops_test.model.applications[certificates].status == "active"
 
-    # deploy MongoDB
-
-    await asyncio.gather(
-        ops_test.model.deploy(
-            DATABASE_CHARM_NAME,
-            application_name=DATABASE_CHARM_NAME,
-            num_units=1,
-            series="jammy",
-            channel="5/edge",
-        ),
-    )
-    await ops_test.model.wait_for_idle(
-        apps=[KAFKA_CHARM_NAME, ZOOKEEPER_CHARM_NAME, DATABASE_CHARM_NAME],
-        status="active",
-        timeout=1200,
-        idle_period=30,
-    )
+    # deploy MongoDB if it's not already deployed
+    if database not in ops_test.model.applications:
+        await asyncio.gather(
+            ops_test.model.deploy(
+                DATABASE_CHARM_NAME,
+                application_name=database,
+                num_units=1,
+                series="jammy",
+                channel="5/edge",
+            ),
+        )
+        await ops_test.model.wait_for_idle(
+            apps=[kafka, zookeeper, database],
+            status="active",
+            timeout=1200,
+            idle_period=30,
+        )
 
 
 @pytest.mark.abort_on_fail
@@ -190,14 +190,14 @@ async def test_test_app_actually_set_up(
 
 
 @pytest.mark.abort_on_fail
-async def test_consumed_messages(ops_test: OpsTest, deploy_data_integrator):
+async def test_consumed_messages(ops_test: OpsTest, deploy_data_integrator, database):
 
     # get mongodb credentials
     mongo_integrator = await deploy_data_integrator({"database-name": TOPIC})
 
-    await ops_test.model.add_relation(mongo_integrator, DATABASE_CHARM_NAME)
+    await ops_test.model.add_relation(mongo_integrator, database)
     await ops_test.model.wait_for_idle(
-        apps=[mongo_integrator, DATABASE_CHARM_NAME], idle_period=30, status="active", timeout=1800
+        apps=[mongo_integrator, database], idle_period=30, status="active", timeout=1800
     )
 
     credentials = await fetch_action_get_credentials(
@@ -209,8 +209,4 @@ async def test_consumed_messages(ops_test: OpsTest, deploy_data_integrator):
 
     check_produced_and_consumed_messages(uris, TOPIC)
 
-    await ops_test.model.applications[DATABASE_CHARM_NAME].remove()
-    await ops_test.model.wait_for_idle(
-        apps=[mongo_integrator], idle_period=10, status="blocked", timeout=1800
-    )
     logger.info("End of the test!")

--- a/tests/integration/e2e/test_basic_flow.py
+++ b/tests/integration/e2e/test_basic_flow.py
@@ -55,6 +55,8 @@ async def test_cluster_is_deployed_successfully(
             timeout=1200,
             idle_period=30,
         )
+        # teardown database at the end of the test
+        pytest.remove_database = True
 
 
 @pytest.mark.abort_on_fail
@@ -208,5 +210,11 @@ async def test_consumed_messages(ops_test: OpsTest, deploy_data_integrator, data
     uris = credentials[DATABASE_CHARM_NAME]["uris"]
 
     check_produced_and_consumed_messages(uris, TOPIC)
+
+    if pytest.remove_database:
+        await ops_test.model.applications[database].remove()
+        await ops_test.model.wait_for_idle(
+            apps=[mongo_integrator], idle_period=10, status="blocked", timeout=1800
+        )
 
     logger.info("End of the test!")

--- a/tests/integration/e2e/test_password_rotation.py
+++ b/tests/integration/e2e/test_password_rotation.py
@@ -57,6 +57,8 @@ async def test_cluster_is_deployed_successfully(
             timeout=1200,
             idle_period=30,
         )
+        # teardown database at the end of the test
+        pytest.remove_database = True
 
 
 @pytest.mark.abort_on_fail
@@ -267,5 +269,11 @@ async def test_consumed_messages(ops_test: OpsTest, deploy_data_integrator, data
     uris = credentials[DATABASE_CHARM_NAME]["uris"]
 
     check_produced_and_consumed_messages(uris, TOPIC)
+
+    if pytest.remove_database:
+        await ops_test.model.applications[database].remove()
+        await ops_test.model.wait_for_idle(
+            apps=[mongo_integrator], idle_period=10, status="blocked", timeout=1800
+        )
 
     logger.info("End of the test!")

--- a/tox.ini
+++ b/tox.ini
@@ -60,7 +60,8 @@ commands =
         --skip {tox_root}/tests/integration/bundle/app-charm/lib \
         --skip {tox_root}/.mypy_cache \
         --skip {tox_root}/poetry.lock \
-        --skip {tox_root}/icon.svg
+        --skip {tox_root}/icon.svg \
+        --skip {tox_root}/terraform/dev
 
     poetry run ruff {[vars]tests_path} --extend-exclude {tox_root}/tests/integration/bundle/app-charm/*.py
     poetry run black --check --diff {[vars]tests_path}


### PR DESCRIPTION
This PR adds the capability of pointing to an existing deployment of MongoDB to store tests metrics. 

If MongoDB is not deployed, then a new instance is deployed.