### PR TITLE
[MISC] Adding ability to trigger workflow manually

### DIFF
--- a/.github/workflows/ci_e2e.yaml
+++ b/.github/workflows/ci_e2e.yaml
@@ -7,6 +7,7 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '53 0 * * SAT' # Every Saturday at 00:53 UTC
 

--- a/.github/workflows/update_bundle.yaml
+++ b/.github/workflows/update_bundle.yaml
@@ -3,6 +3,7 @@
 name: Update bundle
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '53 0 * * *'  # Daily at 00:53 UTC
 


### PR DESCRIPTION
# Description 

This is for being able to trigger update as well as end-2-end tests manually, without the need to wait for the scheduled process to run 