### PR TITLE
Add workflow status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# Kafka Bundle
+# Charmed Kafka Bundle
+[![Charmhub](https://charmhub.io/kafka-bundle/badge.svg)](https://charmhub.io/kafka-bundle)
+[![Release](https://github.com/canonical/kafka-bundle/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/kafka-bundle/actions/workflows/release.yaml)
+[![Tests](https://github.com/canonical/kafka-bundle/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/canonical/kafka-bundle/actions/workflows/ci.yaml)
 
 This repository contains the machine charm bundles for Kafka.
 


### PR DESCRIPTION
## Issue
This repo's status is not displayed in the [Charm Engineering Releases](https://releases.juju.is/?team=Data) overview.

## Solution
Added workflow badges for 
* CharmHub
* Release
* Tests