### PR TITLE
[MISC] Fix release and increase testing on PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,7 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  workflow_dispatch:
   pull_request:
   workflow_call:
   schedule:
@@ -52,7 +53,7 @@ jobs:
   integration-test:
     strategy:
       fail-fast: false
-      max-parallel: 1
+      max-parallel: 5
       matrix:
         tox-environments:
           # - integration-terraform  # disabled until https://github.com/juju/terraform-provider-juju/issues/376 is resolved and released

--- a/.github/workflows/ci_e2e.yaml
+++ b/.github/workflows/ci_e2e.yaml
@@ -8,10 +8,12 @@ concurrency:
 
 on:
   workflow_dispatch:
-  pull_request:
   workflow_call:
-  schedule:
-    - cron: '53 0 * * SAT' # Every Saturday at 00:53 UTC
+  # FIXME: End-to-End tests are failing because of memory issue on
+  #   standard github runners (https://warthogs.atlassian.net/browse/DPE-4083)
+  # pull_request:
+  # schedule:
+  #   - cron: '53 0 * * SAT' # Every Saturday at 00:53 UTC
 
 jobs:
   lint:

--- a/.github/workflows/ci_e2e.yaml
+++ b/.github/workflows/ci_e2e.yaml
@@ -8,6 +8,7 @@ concurrency:
 
 on:
   workflow_dispatch:
+  pull_request:
   workflow_call:
   schedule:
     - cron: '53 0 * * SAT' # Every Saturday at 00:53 UTC

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,9 @@ on:
       - main
 
 jobs:
+  integration-test:
+    uses: ./.github/workflows/ci.yaml
+
   integration-test-e2e:
     uses: ./.github/workflows/ci_e2e.yaml
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,8 +9,10 @@ jobs:
   integration-test:
     uses: ./.github/workflows/ci.yaml
 
-  integration-test-e2e:
-    uses: ./.github/workflows/ci_e2e.yaml
+  # FIXME: End-to-End tests are failing because of memory issue on
+  #   standard github runners (https://warthogs.atlassian.net/browse/DPE-4083)
+  # integration-test-e2e:
+  #   uses: ./.github/workflows/ci_e2e.yaml
 
   publish-bundle:
     name: Publish bundle
@@ -18,7 +20,7 @@ jobs:
     timeout-minutes: 5
     needs:
       - integration-test
-      - integration-test-e2e
+      # - integration-test-e2e
     env:
       CHARMCRAFT_AUTH: ${{ secrets.CHARMHUB_TOKEN }}
     steps:


### PR DESCRIPTION
I'm excluding the E2E tests as they are failing on standard runners. We used to have larger custom runners but they have been disabled, and we should give preference to use self-hosted runners. I have created a ticket in the backlog [DPE-4083](https://warthogs.atlassian.net/browse/DPE-4083), but we can disable them for the time being. 

[DPE-4083]: https://warthogs.atlassian.net/browse/DPE-4083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ