### PR TITLE
[MISC] Pin self-signed-certificates to stable channel

### DIFF
--- a/releases/3/kafka/bundle.yaml
+++ b/releases/3/kafka/bundle.yaml
@@ -6,12 +6,12 @@ applications:
     revision: 166
     series: jammy
   self-signed-certificates:
-    channel: latest/edge
+    channel: latest/stable
     charm: self-signed-certificates
     num_units: 1
     options:
       ca-common-name: canonical
-    revision: 135
+    revision: 155
     series: jammy
   zookeeper:
     channel: 3/edge

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -44,7 +44,7 @@ variable "tls" {
   description = "Defines the TLS application configuration"
   type = object({
     units   = optional(number, 1)
-    channel = optional(string, "edge")
+    channel = optional(string, "stable")
     base    = optional(string, "ubuntu@22.04")
     series  = optional(string, "jammy")
     config = optional(map(string), {

--- a/tests/integration/e2e/conftest.py
+++ b/tests/integration/e2e/conftest.py
@@ -139,7 +139,7 @@ async def deploy_cluster(ops_test: OpsTest, tls):
             application_name=TLS_CHARM_NAME,
             num_units=1,
             series="jammy",
-            channel="edge",
+            channel="stable",
             config={"ca-common-name": "Canonical"},
         )
         await ops_test.model.wait_for_idle(apps=[TLS_CHARM_NAME], timeout=1200)


### PR DESCRIPTION
edge channel for self-signed-certificates was erroring out. It is probably best actually to use stable, over edge, such that if they push something wrong, we don't bust the CI